### PR TITLE
Remove extra semicolon on airbnb

### DIFF
--- a/template/src/store.js
+++ b/template/src/store.js
@@ -10,7 +10,7 @@ const state = {
 }
 
 const mutations = {
-  INCREMENT(state) { state.count++ }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
+  INCREMENT(state) { state.count++ }
 }{{#if_eq lintConfig "airbnb"}};{{/if_eq}}
 
 const actions = {


### PR DESCRIPTION
I had this error because was an extra semicolon on mutations object.
Unexpected token, expected , (13:36)